### PR TITLE
Fix isuue for iOS 27

### DIFF
--- a/main.m
+++ b/main.m
@@ -37,35 +37,36 @@ void new_sceneID_updateWithSettingsDiff_transitionContext_completion(id self, SE
 
     NSString *diffDescription = [arg2 description];
 
-    if ([diffDescription containsString:@"foreground = NotSet"] || 
-        [diffDescription containsString:@"foreground = No"] || 
-        [diffDescription containsString:@"foreground = BSSettingFlagNo"] || 
-        [diffDescription containsString:@"foreground = NO"]) { 
-        return;
-    }
+
+ if ([diffDescription containsString:@"foreground = NotSet"] || 
+       [diffDescription containsString:@"foreground = No"] || 
+     [diffDescription containsString:@"foreground = BSSettingFlagNo"] || 
+     [diffDescription containsString:@"foreground = NO"]) { 
+    return;
+   }
 
     if ([diffDescription containsString:@"hostContextIdentifierForSnapshotting = 0"] || 
-        [diffDescription containsString:@"scenePresenterRenderIdentifierForSnapshotting = 0"] ||
-        [diffDescription containsString:@"targetOfEventDeferringEnvironments = (empty)"]) { 
-        return;
-    }
+      [diffDescription containsString:@"scenePresenterRenderIdentifierForSnapshotting = 0"] ||
+    [diffDescription containsString:@"targetOfEventDeferringEnvironments = (empty)"]) { 
+      return;
+   }
     
-    if ([diffDescription containsString:@"FBSceneSnapshotAction:"]) { 
-        return;
-    }
+  if ([diffDescription containsString:@"FBSceneSnapshotAction:"]) { 
+     return;
+  }
 
-    BOOL isGoingToForeground = [diffDescription containsString:@"foreground = Yes"] || 
-                                [diffDescription containsString:@"foreground = YES"] || 
+/*   BOOL isGoingToForeground = [diffDescription containsString:@"foreground = Yes"] || 
+                            [diffDescription containsString:@"foreground = YES"] || 
                                 [diffDescription containsString:@"foreground = BSSettingFlagYes"];
 
     if (!isGoingToForeground) {
         if ([diffDescription containsString:@"deactivationReasons = systemGesture"] ||
             [diffDescription containsString:@"deactivationReasons = systemAnimation"] ||
-            [diffDescription containsString:@"systemGesture, systemAnimation"]) {
+           [diffDescription containsString:@"systemGesture, systemAnimation"]) {
             return;
         }
     }
-
+*/
     return original_sceneID_updateWithSettingsDiff_transitionContext_completion(self, _cmd, arg1, arg2, arg3, arg4);
 }
 


### PR DESCRIPTION
This fixes an issue on iOS 27 where apps could be terminated after reopening from the background while immortalized.

After testing, the issue appeared to be related to handling certain scene deactivation events. Removing the filtering for deactivationReasons restored normal behavior while preserving the intended immortalization functionality.

Tested scenarios:
- Lock/unlock device
- Minimize and reopen apps repeatedly
- Background execution

No regressions observed during testing.